### PR TITLE
[FIX] 시간 쿼리 자료형 Long → DateTime64 변환 및 TPS 단위 보정

### DIFF
--- a/src/main/java/com/seeker/web/dashboard/repository/DashboardRepository.java
+++ b/src/main/java/com/seeker/web/dashboard/repository/DashboardRepository.java
@@ -26,7 +26,9 @@ public class DashboardRepository {
                 agent_id AS agentId,
                 countIf(status_code >= 400) / count() AS errorRate
             FROM span
-            WHERE start_time BETWEEN :startTime AND :endTime
+            WHERE start_time
+                  BETWEEN fromUnixTimestamp64Milli(:startTime)
+                      AND fromUnixTimestamp64Milli(:endTime)
             GROUP BY agent_id
         """;
 
@@ -42,11 +44,13 @@ public class DashboardRepository {
             SELECT
                 parent_agent_id AS fromAgentId,
                 agent_id AS toAgentId,
-                count() / nullIf((:endTime - :startTime), 0) AS tps,
+                count() / nullIf((:endTime - :startTime) / 1000.0, 0) AS tps,
                 avg(elapsed_time) AS avgLatency,
                 countIf(status_code >= 400) / count() AS errorRate
             FROM span
-            WHERE start_time BETWEEN :startTime AND :endTime
+            WHERE start_time
+                  BETWEEN fromUnixTimestamp64Milli(:startTime)
+                      AND fromUnixTimestamp64Milli(:endTime)
             GROUP BY agent_id, parent_agent_id
         """;
 


### PR DESCRIPTION
## ✨ 작업 개요

대시보드 토폴로지 쿼리에서 시간 범위 필터가 정상 동작하지 않던 문제와, 엣지의 TPS 가 실제 값의 1/1000 으로 계산되던 문제를 함께 수정합니다.

## 📝 변경 사항

- `start_time BETWEEN :startTime AND :endTime` 양쪽 파라미터를 `fromUnixTimestamp64Milli(...)` 로 감싸 Long(ms) ↔ ClickHouse `DateTime64(3)` 비교가 의도대로 동작하도록 변경 (`getTopologyNodes`, `getTopologyEdges`)
- `getTopologyEdges` 의 TPS 분모를 `(:endTime - :startTime) / 1000.0` 으로 변경하여 ms → s 환산 (기존 식은 events/ms 단위라 실제 TPS 의 1/1000 로 표시됨)

## 🔗 관련 이슈

Closes #4

## ✅ 체크리스트

- [ ] 로컬에서 빌드 및 테스트를 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다. (필요한 경우)
- [ ] 리뷰어가 확인하기 쉽도록 변경 사항을 정리했습니다.

## 💬 리뷰어에게

- ClickHouse 의 `span.start_time` 은 `DateTime64(3)` 이고 서버는 epoch milli `Long` 으로 파라미터를 보내고 있습니다. JDBC 가 Long 을 초 단위 epoch 으로 해석하면서 시간 범위에 아무 row 도 안 잡히는 조용한 사고가 있어, 명시적 milli 변환으로 단위를 SQL 레벨에서 박았습니다.
- TPS 수정도 같은 시간 비교 라인에 있어 한 커밋으로 묶었습니다 — 분리된 변경이 필요하면 알려주세요.