### PR TITLE
[FEAT] 토폴로지 응답에 User 노드 추가

### DIFF
--- a/src/main/java/com/seeker/web/dashboard/dto/topolopy/AgentId.java
+++ b/src/main/java/com/seeker/web/dashboard/dto/topolopy/AgentId.java
@@ -1,14 +1,20 @@
 package com.seeker.web.dashboard.dto.topolopy;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-@Getter
 @EqualsAndHashCode
 @RequiredArgsConstructor(staticName = "of")
 public class AgentId {
 
+    public static final AgentId USER = AgentId.of("-1");
+
     private final String value;
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
 
 }

--- a/src/main/java/com/seeker/web/dashboard/dto/topolopy/NodeDto.java
+++ b/src/main/java/com/seeker/web/dashboard/dto/topolopy/NodeDto.java
@@ -7,10 +7,22 @@ import lombok.Getter;
 @Builder
 public class NodeDto {
 
+    private static final AgentId USER_AGENT_ID = AgentId.of("-1");
+    private static final String USER_AGENT_NAME = "USER";
+    private static final String USER_AGENT_TYPE = "USER";
+
     private AgentId agentId;
     private String agentName;
     private String agentType;
     private double errorRate;
+
+    public static NodeDto userNode() {
+        return NodeDto.builder()
+                .agentId(USER_AGENT_ID)
+                .agentName(USER_AGENT_NAME)
+                .agentType(USER_AGENT_TYPE)
+                .build();
+    }
 
     public void setNodeAgent(NodeAgentDto nodeAgent) {
         this.agentName = nodeAgent.getAgentName();

--- a/src/main/java/com/seeker/web/dashboard/dto/topolopy/NodeDto.java
+++ b/src/main/java/com/seeker/web/dashboard/dto/topolopy/NodeDto.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 @Builder
 public class NodeDto {
 
-    private static final AgentId USER_AGENT_ID = AgentId.of("-1");
     private static final String USER_AGENT_NAME = "USER";
     private static final String USER_AGENT_TYPE = "USER";
 
@@ -18,7 +17,7 @@ public class NodeDto {
 
     public static NodeDto userNode() {
         return NodeDto.builder()
-                .agentId(USER_AGENT_ID)
+                .agentId(AgentId.USER)
                 .agentName(USER_AGENT_NAME)
                 .agentType(USER_AGENT_TYPE)
                 .build();

--- a/src/main/java/com/seeker/web/dashboard/service/DashboardService.java
+++ b/src/main/java/com/seeker/web/dashboard/service/DashboardService.java
@@ -33,6 +33,17 @@ public class DashboardService {
         List<NodeDto> nodes = dashboardRepository.getTopologyNodes(timeRangeFilter);
         List<EdgeDto> edges = dashboardRepository.getTopologyEdges(timeRangeFilter);
 
+        enrichNodesWithAgentInfo(nodes);
+        nodes.add(NodeDto.userNode());
+
+        return TopologyDto
+                .builder()
+                .nodes(nodes)
+                .edges(edges)
+                .build();
+    }
+
+    private void enrichNodesWithAgentInfo(List<NodeDto> nodes) {
         List<AgentId> agentIds = nodes.stream()
                 .map(NodeDto::getAgentId)
                 .toList();
@@ -44,12 +55,6 @@ public class DashboardService {
                 node.setNodeAgent(nodeAgent);
             }
         }
-
-        return TopologyDto
-                .builder()
-                .nodes(nodes)
-                .edges(edges)
-                .build();
     }
 
 }


### PR DESCRIPTION


## ✨ 작업 개요

토폴로지 응답에 User 노드 추가하여 응답을 보내는 로직을 추가하였습니다.

## 📝 변경 사항

- 토폴로지 응답에 사용자 진입점을 표현하는 User 노드(agentId=-1) 추가
- User 노드 식별자(id/name/type)를 `NodeDto`의 상수와 정적 팩토리 메서드 `userNode()`로 캡슐화
- `DashboardService.getTopology`의 agent 정보 enrichment 로직을 `enrichNodesWithAgentInfo()`로 분리하여, User 노드가 DB 조회 대상에서 제외되도록 호출 순서 보장


## 🔗 관련 이슈

<!-- 관련 이슈 번호를 적어주세요. 예: Closes #123 -->
Resolves: #6 

## ✅ 체크리스트

- [x] 로컬에서 빌드 및 테스트를 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다. (필요한 경우)
- [x] 리뷰어가 확인하기 쉽도록 변경 사항을 정리했습니다.
