### PR TITLE
[FEAT] Agent Metrics 조회 API 구현

### DIFF
--- a/src/main/java/com/seeker/web/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/seeker/web/dashboard/controller/DashboardController.java
@@ -1,8 +1,8 @@
 package com.seeker.web.dashboard.controller;
 
-import com.seeker.web.dashboard.dto.request.TopologyRequest;
+import com.seeker.web.dashboard.dto.request.TimeRangeRequest;
 import com.seeker.web.dashboard.dto.topolopy.TopologyDto;
-import com.seeker.web.dashboard.service.DashboardService;
+import com.seeker.web.dashboard.service.TopologyService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -13,13 +13,13 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/dashboard")
 public class DashboardController {
 
-    private final DashboardService dashboardService;
+    private final TopologyService topologyService;
 
     @GetMapping("/topology")
     public TopologyDto getTopology(
-            @ModelAttribute TopologyRequest topologyRequest
+            @ModelAttribute TimeRangeRequest timeRangeRequest
     ) {
-        return dashboardService.getTopology(topologyRequest);
+        return topologyService.getTopology(timeRangeRequest);
     }
 
 }

--- a/src/main/java/com/seeker/web/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/seeker/web/dashboard/controller/DashboardController.java
@@ -1,7 +1,10 @@
 package com.seeker.web.dashboard.controller;
 
+import com.seeker.web.dashboard.dto.metrics.AgentMetricsDto;
+import com.seeker.web.dashboard.dto.request.AgentTimeRangeRequest;
 import com.seeker.web.dashboard.dto.request.TimeRangeRequest;
 import com.seeker.web.dashboard.dto.topolopy.TopologyDto;
+import com.seeker.web.dashboard.service.AgentMetricsService;
 import com.seeker.web.dashboard.service.TopologyService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,12 +17,20 @@ import org.springframework.web.bind.annotation.*;
 public class DashboardController {
 
     private final TopologyService topologyService;
+    private final AgentMetricsService agentMetricsService;
 
     @GetMapping("/topology")
     public TopologyDto getTopology(
             @ModelAttribute TimeRangeRequest timeRangeRequest
     ) {
         return topologyService.getTopology(timeRangeRequest);
+    }
+
+    @GetMapping("/metrics")
+    public AgentMetricsDto getTopology(
+            @ModelAttribute AgentTimeRangeRequest agentTimeRangeRequest
+    ) {
+        return agentMetricsService.getAgentMetrics(agentTimeRangeRequest);
     }
 
 }

--- a/src/main/java/com/seeker/web/dashboard/dto/metrics/AgentMetricsDto.java
+++ b/src/main/java/com/seeker/web/dashboard/dto/metrics/AgentMetricsDto.java
@@ -1,0 +1,19 @@
+package com.seeker.web.dashboard.dto.metrics;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AgentMetricsDto {
+
+    private Long totalCount;
+
+    private Long errorCount;
+    private Double errorRate;
+
+    private Double p99;
+    private Double p95;
+    private Double p90;
+
+}

--- a/src/main/java/com/seeker/web/dashboard/dto/query/AgentTimeRangeFilter.java
+++ b/src/main/java/com/seeker/web/dashboard/dto/query/AgentTimeRangeFilter.java
@@ -1,0 +1,22 @@
+package com.seeker.web.dashboard.dto.query;
+
+import lombok.Getter;
+
+@Getter
+public class AgentTimeRangeFilter {
+
+    private final Long startTime;
+    private final Long endTime;
+    private final String agentId;
+
+    private AgentTimeRangeFilter(Long startTime, Long endTime, String agentId) {
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.agentId = agentId;
+    }
+
+    public static AgentTimeRangeFilter of(Long startTime, Long endTime, String agentId) {
+        return new AgentTimeRangeFilter(startTime, endTime, agentId);
+    }
+
+}

--- a/src/main/java/com/seeker/web/dashboard/dto/request/AgentTimeRangeRequest.java
+++ b/src/main/java/com/seeker/web/dashboard/dto/request/AgentTimeRangeRequest.java
@@ -1,0 +1,14 @@
+package com.seeker.web.dashboard.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AgentTimeRangeRequest {
+
+    private Long startTime;
+    private Long endTime;
+    private String agentId;
+
+}

--- a/src/main/java/com/seeker/web/dashboard/dto/request/TimeRangeRequest.java
+++ b/src/main/java/com/seeker/web/dashboard/dto/request/TimeRangeRequest.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class TopologyRequest {
+public class TimeRangeRequest {
 
     private Long startTime;
     private Long endTime;

--- a/src/main/java/com/seeker/web/dashboard/repository/AgentMetricsRepository.java
+++ b/src/main/java/com/seeker/web/dashboard/repository/AgentMetricsRepository.java
@@ -1,0 +1,79 @@
+package com.seeker.web.dashboard.repository;
+
+import com.seeker.web.dashboard.dto.metrics.AgentMetricsDto;
+import com.seeker.web.dashboard.dto.query.AgentTimeRangeFilter;
+import com.seeker.web.dashboard.dto.query.TimeRangeFilter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class AgentMetricsRepository {
+
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+    public AgentMetricsDto getAgentMetrics(AgentTimeRangeFilter agentTimeRangeFilter) {
+        String AgentMetricsSql = """
+            SELECT
+                count() AS totalCount,
+                countIf(status_code >= 400) AS errorCount,
+                countIf(status_code >= 400) / count() AS errorRate,
+        
+                quantile(0.99)(elapsed_time) AS p99,
+                quantile(0.95)(elapsed_time) AS p95,
+                quantile(0.90)(elapsed_time) AS p90
+            FROM span
+            WHERE agent_id = :agentId
+              AND start_time
+                  BETWEEN fromUnixTimestamp64Milli(:startTime)
+                      AND fromUnixTimestamp64Milli(:endTime)
+        """;
+
+        return namedParameterJdbcTemplate.queryForObject(
+                AgentMetricsSql,
+                new BeanPropertySqlParameterSource(agentTimeRangeFilter),
+                agentMetricsRowMapper
+        );
+    }
+
+
+    public AgentMetricsDto getUserMetrics(TimeRangeFilter timeRangeFilter) {
+        String AgentMetricsSql = """
+            SELECT
+                count() AS totalCount,
+                countIf(status_code >= 400) AS errorCount,
+                countIf(status_code >= 400) / count() AS errorRate,
+        
+                quantile(0.99)(elapsed_time) AS p99,
+                quantile(0.95)(elapsed_time) AS p95,
+                quantile(0.90)(elapsed_time) AS p90
+            FROM trace
+            WHERE start_time
+                  BETWEEN fromUnixTimestamp64Milli(:startTime)
+                      AND fromUnixTimestamp64Milli(:endTime)
+        """;
+
+        return namedParameterJdbcTemplate.queryForObject(
+                AgentMetricsSql,
+                new BeanPropertySqlParameterSource(timeRangeFilter),
+                agentMetricsRowMapper
+        );
+    }
+
+    private final RowMapper<AgentMetricsDto> agentMetricsRowMapper = ((rs, rowNum) -> {
+        return AgentMetricsDto
+                .builder()
+                .totalCount(rs.getLong("totalCount"))
+                .errorCount(rs.getLong("errorCount"))
+                .errorRate(rs.getDouble("errorRate"))
+                .p99(rs.getDouble("p99"))
+                .p95(rs.getDouble("p95"))
+                .p90(rs.getDouble("p90"))
+                .build();
+    });
+}

--- a/src/main/java/com/seeker/web/dashboard/repository/TopologyRepository.java
+++ b/src/main/java/com/seeker/web/dashboard/repository/TopologyRepository.java
@@ -16,7 +16,7 @@ import java.util.List;
 @Slf4j
 @Repository
 @RequiredArgsConstructor
-public class DashboardRepository {
+public class TopologyRepository {
 
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 

--- a/src/main/java/com/seeker/web/dashboard/service/AgentMetricsService.java
+++ b/src/main/java/com/seeker/web/dashboard/service/AgentMetricsService.java
@@ -1,0 +1,41 @@
+package com.seeker.web.dashboard.service;
+
+import com.seeker.web.dashboard.dto.metrics.AgentMetricsDto;
+import com.seeker.web.dashboard.dto.query.AgentTimeRangeFilter;
+import com.seeker.web.dashboard.dto.query.TimeRangeFilter;
+import com.seeker.web.dashboard.dto.request.AgentTimeRangeRequest;
+import com.seeker.web.dashboard.dto.topolopy.AgentId;
+import com.seeker.web.dashboard.repository.AgentMetricsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AgentMetricsService {
+
+    private final AgentMetricsRepository agentMetricsRepository;
+
+    public AgentMetricsDto getAgentMetrics(AgentTimeRangeRequest agentTimeRangeRequest) {
+
+        AgentId agentId = AgentId.of(agentTimeRangeRequest.getAgentId());
+
+        if (AgentId.USER.equals(agentId)) {
+            TimeRangeFilter timeRangeFilter = TimeRangeFilter.of(
+                    agentTimeRangeRequest.getStartTime(),
+                    agentTimeRangeRequest.getEndTime()
+            );
+            return agentMetricsRepository.getUserMetrics(timeRangeFilter);
+        }
+
+        AgentTimeRangeFilter agentTimeRangeFilter = AgentTimeRangeFilter.of(
+                agentTimeRangeRequest.getStartTime(),
+                agentTimeRangeRequest.getEndTime(),
+                agentTimeRangeRequest.getAgentId()
+        );
+        return agentMetricsRepository.getAgentMetrics(agentTimeRangeFilter);
+
+    }
+
+}

--- a/src/main/java/com/seeker/web/dashboard/service/TopologyService.java
+++ b/src/main/java/com/seeker/web/dashboard/service/TopologyService.java
@@ -1,14 +1,14 @@
 package com.seeker.web.dashboard.service;
 
 import com.seeker.web.dashboard.dto.query.TimeRangeFilter;
-import com.seeker.web.dashboard.dto.request.TopologyRequest;
+import com.seeker.web.dashboard.dto.request.TimeRangeRequest;
 import com.seeker.web.dashboard.dto.topolopy.AgentId;
 import com.seeker.web.dashboard.dto.topolopy.EdgeDto;
 import com.seeker.web.dashboard.dto.topolopy.NodeAgentDto;
 import com.seeker.web.dashboard.dto.topolopy.NodeDto;
 import com.seeker.web.dashboard.dto.topolopy.TopologyDto;
 import com.seeker.web.dashboard.repository.AgentRepository;
-import com.seeker.web.dashboard.repository.DashboardRepository;
+import com.seeker.web.dashboard.repository.TopologyRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -19,19 +19,19 @@ import java.util.Map;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class DashboardService {
+public class TopologyService {
 
-    private final DashboardRepository dashboardRepository;
+    private final TopologyRepository topologyRepository;
     private final AgentRepository agentRepository;
 
-    public TopologyDto getTopology(TopologyRequest topologyRequest) {
+    public TopologyDto getTopology(TimeRangeRequest timeRangeRequest) {
 
         TimeRangeFilter timeRangeFilter = TimeRangeFilter.of(
-                topologyRequest.getStartTime(), topologyRequest.getEndTime()
+                timeRangeRequest.getStartTime(), timeRangeRequest.getEndTime()
         );
 
-        List<NodeDto> nodes = dashboardRepository.getTopologyNodes(timeRangeFilter);
-        List<EdgeDto> edges = dashboardRepository.getTopologyEdges(timeRangeFilter);
+        List<NodeDto> nodes = topologyRepository.getTopologyNodes(timeRangeFilter);
+        List<EdgeDto> edges = topologyRepository.getTopologyEdges(timeRangeFilter);
 
         enrichNodesWithAgentInfo(nodes);
         nodes.add(NodeDto.userNode());


### PR DESCRIPTION
## ✨ 작업 개요

특정 에이전트(또는 USER 노드)의 시간 구간별 **트래픽/에러/지연 지표**를 한 번의 API 호출로 반환하는 백엔드를 구현합니다.
대시보드의 토폴로지 맵에서 노드 선택 시 표시될 KPI 영역의 데이터 소스입니다.

또한 토폴로지 도메인의 객체 명칭을 책임에 맞게 정리하여 후속 도메인(metrics)과의 경계가 분명해지도록 리팩터링을 함께 포함합니다.

## 📝 변경 사항

### 1. API
| Method | Path | 설명 |
|---|---|---|
| GET | `/dashboard/metrics` | 시간 구간 내 특정 agent의 메트릭 집계 조회 |

**Request**
```
GET /dashboard/metrics?startTime={epochMillis}&endTime={epochMillis}&agentId={string}
```
- `startTime`, `endTime`: epoch milliseconds (`DateTime64(3)` 단위와 일치)
- `agentId`: 대상 에이전트. **`-1` 이면 USER 노드** 로 인식하여 `trace` 테이블에서 집계

**Response (`AgentMetricsDto`)**
```json
{
  "totalCount": 0,
  "errorCount": 0,
  "errorRate": 0.0,
  "p99": 0.0,
  "p95": 0.0,
  "p90": 0.0
}
```

### 2. USER vs Agent 분기

`AgentId.USER`(`-1`)는 DB에 적재되지 않는 가상 노드이므로, 메트릭 소스 테이블이 다릅니다.

| 대상 | 소스 테이블 | 식별 |
|---|---|---|
| 일반 agent | `span` | `agent_id = :agentId` |
| USER 노드 | `trace` | (agent_id 없음, 시간 구간으로만 필터) |

서비스 레이어에서 `AgentId.USER.equals(agentId)` 한 곳에서만 분기하고, 각 분기에서 필요한 `TimeRangeFilter` / `AgentTimeRangeFilter`만 생성합니다.

### 3. 계층별 책임
- **Controller** `DashboardController` — `/dashboard/metrics` 엔드포인트 추가
- **Service** `AgentMetricsService` — USER/Agent 분기 + 필터 조립
- **Repository** `AgentMetricsRepository`
  - `getAgentMetrics(AgentTimeRangeFilter)` — `span` 집계
  - `getUserMetrics(TimeRangeFilter)` — `trace` 집계
  - 두 쿼리 모두 `count()` / `countIf(status_code >= 400)` / `quantile(0.99|0.95|0.90)` 을 단일 쿼리로 산출
- **DTO**
  - `AgentMetricsDto` — totalCount / errorCount / errorRate / p99 / p95 / p90
  - `AgentTimeRangeRequest` — `startTime`, `endTime`, `agentId`
  - `AgentTimeRangeFilter` — request → query 매핑 (`AgentId` 값 객체 래핑)

### 4. 리팩터링 (관련 객체 명칭 정리)
metrics 도메인이 추가되면서 기존 "Dashboard~" 명칭의 모호함이 드러나, 책임에 맞게 이름을 좁혔습니다.

| Before | After |
|---|---|
| `DashboardService` | `TopologyService` |
| `DashboardRepository` | `TopologyRepository` |
| `TopologyRequest` | `TimeRangeRequest` |

> `Dashboard`는 컨트롤러 라우팅 prefix로만 남기고, 서비스/리포지토리는 도메인(`Topology`, `AgentMetrics`) 단위로 분리되었습니다.


## 🔗 관련 이슈

<!-- 관련 이슈 번호를 적어주세요. 예: Closes #123 -->
Resolves #3 

## ✅ 체크리스트

- [x] 로컬에서 빌드 및 테스트를 통과했습니다.
  - [x] mock data를 db에 적재하여 api 호출을 테스트하였습니다. 
- [ ] 관련 문서를 업데이트했습니다. (필요한 경우)
  - 노션의 API 명세는 산점도 그래프 api까지 완료 후 업데이트 하겠습니다.
- [x] 리뷰어가 확인하기 쉽도록 변경 사항을 정리했습니다.

